### PR TITLE
Change all rem units to base 16, from base 10

### DIFF
--- a/src/sass/abstracts/_mixins.scss
+++ b/src/sass/abstracts/_mixins.scss
@@ -1,10 +1,10 @@
 /* Media queries: mobile first design */
 @mixin for-tablet-up {
-  @media only screen and (min-width: 40em) { @content; } //640px
+  @media only screen and (min-width: 40em) { @content; } //16 * 40 = 640px
 }
 
 @mixin for-desktop-up {
-  @media only screen and (min-width: 53.125em) { @content; } //850px
+  @media only screen and (min-width: 53.125em) { @content; } //16 * 53.125 = 850px
 }
 
 /* Fluid Typography, Heigh, and Width Mixins */
@@ -16,14 +16,7 @@
   @return $value / ($value * 0 + 1);
 }
 
-//Turns pixels into rem
-@function calculate-rem($size) {
-  $remSize: $size / 10px; //1rem = 10px, :root font-size is 62.5%, not 100%
-
-  @return #{$remSize}rem;
-}
-
-//Used to create fluid typography, variables must always be in pixels, outputs to rems
+//Used to create fluid typography
 @mixin fluid-type($min-vw, $max-vw, $min-font-size, $max-font-size) {
   $u1: unit($min-vw);
   $u2: unit($max-vw);
@@ -32,20 +25,20 @@
 
   @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 {
     & {
-      font-size: calculate-rem($min-font-size);
+      font-size: $min-font-size;
 
       @media screen and (min-width: $min-vw) {
-        font-size: calc(#{calculate-rem(#{$min-font-size} + #{strip-unit($max-font-size - $min-font-size)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)}))});
+        font-size: calc(#{$min-font-size} + #{strip-unit($max-font-size - $min-font-size)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)}));
       }
 
       @media screen and (min-width: $max-vw) {
-        font-size: calculate-rem($max-font-size); //Takes pixels and outputs to rems
+        font-size: $max-font-size;
       }
     }
   }
 }
 
-//Used to create fluid widths, variables must always be in pixels, outputs to rems
+//Used to create fluid widths
 @mixin fluid-width($min-viewport, $max-viewport, $min-item-width, $max-item-width) {
   $a1: unit($min-viewport);
   $a2: unit($max-viewport);
@@ -67,7 +60,7 @@
   }
 }
 
-//Used to create fluid heights, variables must always be in pixels, outputs to rems
+//Used to create fluid heights
 @mixin fluid-height($min-window-size, $max-window-size, $min-item-height, $max-item-height) {
   $a1: unit($min-window-size);
   $a2: unit($max-window-size);

--- a/src/sass/abstracts/_variables.scss
+++ b/src/sass/abstracts/_variables.scss
@@ -31,35 +31,39 @@ $easeOutBack: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 $button-down-press: translateY(2px);
 
 /* Fluid typography variables for index.html and contact.html */
-$min-width-i: 320px;
-$max-width-i: 560px;
-$min-font-i: 16px;
-$max-font-i: 18px;
+$min-width-i: 20rem;
+$max-width-i: 35rem;
+$min-font-i: 1rem;
+$max-font-i: 1.125rem;
 
 /* Fluid typography variables for the navigation bar */
-$min-width-nav: 320px;
-$max-width-nav: 1000px;
-$min-font-nav: 9px;
-$max-font-nav: 16px;
+$min-width-nav: 20rem;
+$max-width-nav: 62.5rem;
+$min-font-nav: 0.5625rem;
+$max-font-nav: 1rem;
 
 /* Fluid width variables for svg icons in the navigation bar */
-$min-vw-nav-icons: 32px;
-$max-vw-nav-icons: 1000px;
-$min-width-nav-icons: 16px;
-$max-width-nav-icons: 24px;
+$min-vw-nav-icons: 2rem;
+$max-vw-nav-icons: 62.5rem;
+$min-width-nav-icons: 1rem;
+$max-width-nav-icons: 1.5rem;
+
+/* Fluid height variables for svg icons in the navigation bar */
+$min-height-nav-icons: 1rem;
+$max-height-nav-icons: 1.5rem;
 
 /* Fluid width variables for the Wittenbrock logo in the navigation bar */
-$min-vw-nav-logo: 320px;
-$max-vw-nav-logo: 850px;
-$min-width-nav-logo: 35px;
-$max-width-nav-logo: 65px;
+$min-vw-nav-logo: 20rem;
+$max-vw-nav-logo: 53.125rem;
+$min-width-nav-logo: 2.1875rem;
+$max-width-nav-logo: 4.0625rem;
 
 /* Fluid height variables for the Wittenbrock logo in the navigation bar */
-$min-height-nav-logo: 35px;
-$max-height-nav-logo: 65px;
+$min-height-nav-logo: 2.1875rem;
+$max-height-nav-logo: 4.0625rem;
 
 /* Fluid height variables for the navigation bar's height */
-$min-vw-nav-bar: 320px;
-$max-vw-nav-bar: 850px;
-$min-height-nav-bar: 50px;
-$max-height-nav-bar: 80px;
+$min-vw-nav-bar: 20rem;
+$max-vw-nav-bar: 53.125rem;
+$min-height-nav-bar: 3.125rem;
+$max-height-nav-bar: 5rem;

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -1,8 +1,8 @@
 html {
   box-sizing: border-box;
-  font-size: 62.5%; /* 1rem = 10px */
+  font-size: 100%; //1rem = 16px
   background-color: $white;
-  min-width: 307px;
+  min-width: 19.1875px; //307px
 }
 
 *,
@@ -37,10 +37,10 @@ p,
 header {
   @include fluid-type($min-width-i, $max-width-i, $min-font-i, $max-font-i);
 
-  margin-bottom: 1.44rem;
+  margin-bottom: 0.9rem; //14.4px
 
   @include for-tablet-up {
-    margin-bottom: 1.6rem; //16px
+    margin-bottom: 1rem; //16px
   }
 }
 

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -1,14 +1,14 @@
 %button-base-styles {
   display: block;
-  width: 7rem;
+  width: 4.375rem; //70px
   background: $hover-color;
   font-family: $font-stack;
-  font-size: 1rem;
+  font-size: 0.625rem; //10px
   color: $white;
   text-transform: uppercase;
   font-weight: 300;
   text-align: center;
-  padding: 0.6rem 1.4rem;
+  padding: 0.375rem 0.875rem; //6px 14px
   border: 2px solid $hover-color;
   border-radius: 5px;
   box-shadow: $project-button-shadow;
@@ -33,14 +33,13 @@
 
   background-color: $light-grey;
   display: inline-block;
-  margin-right: 2rem;
+  margin-right: 1.25rem; //20px
 }
 
 .github-button {
   background: #818181;
   border: solid 2px $light-grey;
-  margin-left: 2rem;
-  margin-right: 0;
+  margin-left: 1.25rem; //20px
 
   &:active {
     color: $white;
@@ -60,8 +59,8 @@
 .form-button {
   @extend %button-base-styles;
 
-  margin: 3rem auto;
-  width: 15rem;
+  margin: 1.875rem auto; //30px
+  width: 9.375rem; //150px
 
   &:active {
     box-shadow: none; //remove blue box-shadow from Mozilla Firefox

--- a/src/sass/components/_nav-bar.scss
+++ b/src/sass/components/_nav-bar.scss
@@ -16,7 +16,7 @@
 
 .nav-bar {
   width: 100%;
-  max-width: 100rem;
+  max-width: 62.5rem; //1000px
 }
 
 .nav-list {
@@ -29,7 +29,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex: 1 1 8rem;
+  flex: 1 1 3.125rem; //50px
 }
 
 .nav-icon {
@@ -42,6 +42,7 @@
 
 .nav-svg {
   @include fluid-width($min-vw-nav-icons, $max-vw-nav-icons, $min-width-nav-icons, $max-width-nav-icons);
+  @include fluid-height($min-vw-nav-icons, $max-vw-nav-icons, $min-height-nav-icons, $max-height-nav-icons);
 
   height: auto;
   fill: $black;

--- a/src/sass/components/_social-media-icons.scss
+++ b/src/sass/components/_social-media-icons.scss
@@ -13,19 +13,19 @@
 
 .social-media-icon {
   display: inline-block;
-  height: 36px;
-  width: 36px;
-  margin-left: 2rem;
-  margin-right: 2rem;
-  margin-top: 14rem;
-  margin-bottom: 2rem;
+  height: 2.25rem; //36px
+  width: 2.25rem; //36px
+  margin-left: 1.25rem; //20px
+  margin-right: 1.25rem; //20px
+  margin-top: 8.75rem; //140px
+  margin-bottom: 1.25rem; //20px
 
-  @media screen and (min-width: 350px) and (max-width: 500px) {
-    margin-top: 12rem;
+  @media screen and (min-width: 21.875em) and (max-width: 31.25em) { //350px 500px
+    margin-top: 8.75rem; //120px
   }
 
   @include for-desktop-up {
-    margin-top: 12rem;
+    margin-top: 7.5rem; //120px
 
     &:hover .icon {
       fill: $background-color;

--- a/src/sass/components/_wittenbrock-logo.scss
+++ b/src/sass/components/_wittenbrock-logo.scss
@@ -14,16 +14,16 @@
   @extend %wittenbrock-design-logo;
 
   margin: auto;
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+  margin-top: 1.875rem; //30px
+  margin-bottom: 1.875rem; //30px
   width: 85px;
   height: 85px;
 
   @include for-tablet-up {
     width: 90px;
     height: 90px;
-    margin-top: 4rem;
-    margin-bottom: 4rem;
+    margin-top: 2.5rem; //40px
+    margin-bottom: 2.5rem; //40ox
   }
 }
 

--- a/src/sass/pages/_contact-html.scss
+++ b/src/sass/pages/_contact-html.scss
@@ -1,8 +1,7 @@
 .flexible-subtitle {
   display: block;
 
-  @media screen and (min-width: 47em) {
-    //752px
+  @media screen and (min-width: 47em) { //752px
     display: inline;
   }
 }
@@ -27,33 +26,33 @@
 }
 
 .form-label {
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem; //20px
 }
 
 .form-input {
-  height: 5rem;
+  height: 3.125rem; //50px
   width: 100%;
 
   @include for-tablet-up {
-    width: 26.5rem;
+    width: 16.5625rem; //265px
   }
 }
 
 .name-input {
-  margin-right: 3rem;
+  margin-right: 1.875rem; //30px
 }
 
 .form-textarea {
   width: 100%;
-  height: 20rem;
+  height: 12.5rem; //200px
   line-height: 1.5;
 }
 
 .form-input,
 .form-textarea {
-  margin-top: 1rem;
+  margin-top: 0.625rem; //10px
   border-radius: 4px;
-  padding: 1.5rem;
+  padding: 0.9375rem; //15px
   border: 1px solid #dadcdd;
 
   &:focus {

--- a/src/sass/pages/_index-html.scss
+++ b/src/sass/pages/_index-html.scss
@@ -26,12 +26,12 @@
 
 .about {
   margin: auto;
-  max-width: 51rem;
-  padding: 2rem;
+  max-width: 31.875rem; //510px
+  padding: 1.25rem; //20px
   padding-top: 0;
 
   @include for-tablet-up {
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem; //40px
     text-align: justify;
   }
 }
@@ -39,13 +39,11 @@
 .article-header {
   display: inline;
 
-  @media screen and (min-width: 29.81em) {
-    //477px
+  @media screen and (min-width: 29.81em) { //477px
     display: block;
   }
 
-  @media screen and (min-width: 20em) {
-    //320px
+  @media screen and (min-width: 20em) { //320px
     display: inline;
   }
 }
@@ -54,14 +52,12 @@
   display: block;
   font-weight: 300;
 
-  @media screen and (min-width: 20.125em) {
-    //322px
+  @media screen and (min-width: 20.125em) { //322px
     display: inline;
-    padding-left: 0.5rem;
+    padding-left: 0.3125rem; //5px
   }
 
-  @media screen and (min-width: 30.5rem) {
-    //488px
+  @media screen and (min-width: 30.5em) { //488px
     display: block;
     padding-left: 0;
   }
@@ -69,8 +65,8 @@
 
 .translatable-text {
   position: absolute;
-  max-width: 47rem;
-  margin-right: 2rem;
+  max-width: 29.375rem; //470px
+  margin-right: 1.25rem; //20px
 }
 
 .svg-icon-handler {
@@ -79,17 +75,18 @@
 }
 
 .translate-button-container {
-  width: 1.7rem; //If height and width are larger, <p> element's height be higher than all the others (27px).
-  height: 1.7rem;
-  margin-right: 2rem;
+  width: 1.0625rem; // 17px
+  // If height and width are larger, the svg's <p> element's height is higher than all the others (27px).
+  height: 1.0625rem;
+  margin-right: 1.25rem; //20px
 }
 
 .translate-button {
   position: absolute;
-  top: -0.6rem;
+  top: -0.375rem; //-6px
   fill: $black;
-  width: 3.1rem;
-  height: 3.1rem;
+  width: 1.9375rem; //31px
+  height: 1.9375rem; //31px
   cursor: pointer;
 
   @include for-desktop-up {
@@ -119,10 +116,10 @@
     &::after {
       content: '';
       position: absolute;
-      bottom: 0.1rem;
+      bottom: 0.0625rem; //1px
       left: 0;
       right: 0;
-      height: 0.05rem;
+      height: 0.0625rem; //1px
       background-color: $hover-color;
     }
 

--- a/src/sass/pages/_message-sent-html.scss
+++ b/src/sass/pages/_message-sent-html.scss
@@ -1,14 +1,13 @@
 .page-header-container {
   //This class is also declared in _recent-work-html.scss
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: 1.25rem; //20px
+  padding-right: 1.252rem; //20px
 }
 
 .title-flexible-display {
   display: block;
 
-  @media screen and (min-width: 27.1875em) {
-    //436px
+  @media screen and (min-width: 27.1875em) { //436px
     display: inline;
   }
 }
@@ -16,8 +15,7 @@
 .flexible-display {
   display: inline;
 
-  @media screen and (min-width: 25em) {
-    //400px
+  @media screen and (min-width: 25em) { //400px
     display: block;
   }
 }

--- a/src/sass/pages/_recent-work-html.scss
+++ b/src/sass/pages/_recent-work-html.scss
@@ -1,30 +1,29 @@
 .page-header-container {
-  margin-top: 6rem;
-  margin-bottom: 7rem;
+  margin-top: 3.75rem; //60px
+  margin-bottom: 4.375rem; //70px
 }
 
 .page-title {
   font-family: $font-stack;
   font-weight: 500;
   text-align: center;
-  font-size: 2.5rem;
+  font-size: 1.5625rem; //25px
   color: $black;
 
   @include for-tablet-up {
-    // font-size: 3.8rem;
-    font-size: 3rem;
+    font-size: 1.875rem; //30px
   }
 }
 
 .page-subtitle {
   text-align: center;
-  font-size: 1.8rem;
+  font-size: 1.125rem; //18px
   font-weight: 300;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: 1.25rem; //20px
+  padding-right: 1.25rem; //20px
 
   @include for-tablet-up {
-    font-size: 1.8rem;
+    font-size: 1.125rem; //18px
   }
 }
 
@@ -33,12 +32,12 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  max-width: 110rem;
-  margin-top: 11rem;
-  padding-bottom: 1rem;
+  max-width: 68.75rem; //1100px
+  margin-top: 6.875rem; //110px
+  padding-bottom: 0.625rem; //10px
 
   @include for-desktop-up {
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem; //40px
   }
 }
 
@@ -46,18 +45,18 @@
   display: flex; //put projects into a centered column down the page
   flex-direction: column;
   align-items: center;
-  margin-bottom: 10rem;
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
+  margin-bottom: 6.25rem; //100px
+  margin-left: 1.5625rem; //25px
+  margin-right: 1.5625rem; //25px
 
   @include for-tablet-up {
-    margin-left: 4rem;
-    margin-right: 4rem;
+    margin-left: 2.5rem; //40px
+    margin-right: 2.5rem; //40px
   }
 
   @include for-desktop-up {
     position: relative; //allow for absolute positioning of .project-caption
-    margin-bottom: 7rem;
+    margin-bottom: 4.375rem; //70px
   }
 }
 
@@ -67,8 +66,7 @@
   flex-direction: column;
   box-shadow: $project-caption-shadow;
 
-  @media screen and (min-width: 31.25em) and (max-width: 39.9em) {
-    //500px ~ 638px
+  @media screen and (min-width: 31.25em) and (max-width: 39.9em) {//500px ~ 638px
     width: 85%;
   }
 
@@ -84,14 +82,14 @@
 }
 
 .project-transition {
-  //AOS (animate on scroll) uses transitions to animate its elements. Because of this, it JavaScript overrides any written transitions not related to AOS.
-  order: 2; //goes against normal document flow, this shows picture above caption
+  //AOS (animate on scroll) uses transitions to animate its elements. Because of this, its JavaScript overrides any written transitions not related to AOS.
+  order: 2; //goes against normal document flow, this puts the picture above caption
   transition: transform 0.5s ease-in-out;
 
   @include for-desktop-up {
     position: absolute;
-    z-index: 2; //Put the caption above the project's image
-    margin-top: 7rem;
+    z-index: 2; //Elevate the caption above the project's image
+    margin-top: 4.375rem; //70px
 
     &:hover {
       transform: scale(1.1);
@@ -109,49 +107,49 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 2rem;
+  padding: 1.25rem; //20px
   background: $white;
 
   @include for-desktop-up {
-    width: 42rem;
+    width: 26.25rem; //420px
     box-shadow: $project-caption-shadow;
-    min-height: 22.5rem;
+    min-height: 14.0625rem; //225px
   }
 }
 
 .caption-right {
-  right: 0.25rem;
+  right: 0.03125rem; //2.5px
 }
 
 .caption-left {
-  left: 0.25rem;
+  left: 0.03125rem; //2.5px
 }
 
 .project-title {
   font-weight: 500;
-  font-size: 2.2rem;
+  font-size: 1.375rem; //22px
   color: $black;
   margin-bottom: 0;
 
   @include for-tablet-up {
-    font-size: 2rem;
+    font-size: 1.25rem; //20px
   }
 }
 
 .project-subtitle {
-  font-size: 1.7rem;
+  font-size: 1.0625rem; //17px
   font-weight: 100;
   color: $light-grey;
 
   @include for-tablet-up {
-    font-size: 1.5rem;
+    font-size: 0.9375rem; //15px
   }
 }
 
 .project-description {
-  font-size: 1.3rem;
+  font-size: 0.8125rem; //13px
   text-align: justify;
-  line-height: 2.3rem;
+  line-height: 1.4375rem; //23px
 }
 
 .project-image-transition {
@@ -162,10 +160,6 @@
     width: 65%;
     transition: transform 0.5s ease-in-out;
   }
-}
-
-.project-image {
-  height: 100%;
 }
 
 .image-right {


### PR DESCRIPTION
The fluid-typography, fluid-width, and fluid-height functions were
using pixels. I wanted to have these functions output rems, not pixels.
However, because the html font-size was 1rem = 10px, the functions
weren't working. Refactoring back to 1rem = 16px fixed this.