### PR TITLE
Fix the podcast grid layout

### DIFF
--- a/src/homepage.html
+++ b/src/homepage.html
@@ -90,14 +90,14 @@
       </article>
   </section>
   <section class="podcasts">
-    <div class="podcasts-part-one">
+
       <header class="podcasts-section-header">
         <h2 class="section-title">I love podcasts.</h2>
         <p class="subtitle">
           <span>These are a few of the podcasts that I enjoy,</span>
           <span class="podcast-subtitle-break-point">that I hope you might enjoy as well.</span>
       </header>
-      <figure class="podcast-grid-one">
+      <figure class="podcast-grid">
         <!-- Reply All -->
         <div class="podcast-item">
           <h3 class="screen-reader-only">Reply All</h3>
@@ -137,11 +137,7 @@
             </a>
           </div>
         </div>
-      </figure>
-    </div>
-    <div class="podcasts-part-two">
       <!-- How I Built This -->
-      <figure class="podcast-grid-two">
         <div class="podcast-item">
           <h3 class="screen-reader-only">How I Built</h3>
           <img src="assets/images/resized-photos/podcast-earhustle.0.jpg" alt="">
@@ -220,10 +216,9 @@
           </div>
         </div>
       </figure>
-    </div>
   </section>
   <section class="contact">
-    <header class="contact-header">
+    <header class="contact-section-header">
       <h2 class="section-title">Drop me a line.</h2>
       <p class="contact-subtitle">My coding mind is always open.</p>
       <div class="social-media-container">

--- a/src/sass/abstracts/_variables.scss
+++ b/src/sass/abstracts/_variables.scss
@@ -162,9 +162,9 @@ $max-margin-podcast-titles: 0.75rem;
 $min-margin-podcast-date: 1.55rem;
 $max-margin-podcast-date: 4rem;
 
-/* Fluid margin-bottom dimensions for .contact */
-$min-margin-contact: 6rem;
-$max-margin-contact: 8rem;
+/* Fluid padding-top, padding-bottom, margin-bottom dimensions for .podcasts, .contact, .podcasts-section-header, and .contact-section-header */
+$min-padding-section: 6rem;
+$max-padding-section: 8rem;
 
 /* Fluid padding dimensions for .contact-form */
 $min-padding-contact-form: 2.25rem;

--- a/src/sass/layout/_contact.scss
+++ b/src/sass/layout/_contact.scss
@@ -1,34 +1,39 @@
 .contact {
-  @include fluid-property('margin-bottom', $min-vw-320px, $max-vw-1440px, $min-margin-contact, $max-margin-contact);
+  @include fluid-property('padding-top', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section);
 
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  min-width: 100vw;
-  border: 2px solid red;
+  justify-content: center;
+  width: 100vw;
+  min-height: 100vh;
 
-  @include for-desktop-up {
+  @media screen and (min-width: 600px) {
+    @include fluid-property('padding-bottom', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section);
+  }
+
+  @media screen and (min-width: 900px) {
     flex-direction: row;
     justify-content: center;
-    min-height: 60vh;
+    align-items: center;
   }
 }
 
-.contact-header {
+.contact-section-header {
+  @include fluid-property('margin-bottom', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section); /* This is the same dimension as .contact's top and bottom padding */
+
   flex-basis: 50%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   max-height: rem(512px);
-  margin-bottom: rem(96px);
 
   @media screen and (min-width: 900px) {
     margin: 0;
   }
 
   @media screen and (min-width: 1600px) {
-    flex-basis: rem(800px);
+    flex-basis: rem(512px);
   }
 }
 
@@ -66,7 +71,7 @@
 
   @media screen and (min-width: 1600px) {
     background: none;
-    flex-basis: rem(800px);
+    flex-basis: rem(512px);
   }
 }
 
@@ -78,7 +83,6 @@
   display: flex;
   flex-direction: column;
   flex-basis: rem(512px);
-  height: 100%;
   background: $white;
 }
 

--- a/src/sass/layout/_landing-page.scss
+++ b/src/sass/layout/_landing-page.scss
@@ -1,10 +1,13 @@
 /* Styles related to the Wittenbrock logo are located in sass/components/_wittenbrock-logo.scss */
 %basic-section-styles {
+  @include fluid-property('padding-top', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section);
+  @include fluid-property('padding-bottom', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section);
+
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-width: 100vw;
+  width: 100vw;
   min-height: 100vh;
   border: 2px solid red;
 }

--- a/src/sass/layout/_podcasts.scss
+++ b/src/sass/layout/_podcasts.scss
@@ -2,23 +2,11 @@
   @extend %basic-section-styles;
 }
 
-/* All of the relevant styles nested in .podcasts-part-one */
-
-.podcasts-part-one {
-  @include fluid-property('margin-left', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
-  @include fluid-property('margin-right', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
-
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  min-height: 100vh;
-}
-
 .podcasts-section-header {
-  padding-left: rem(16px);
-  padding-right: rem(16px);
-  margin: auto;
+  @include fluid-property('margin-bottom', $min-vw-320px, $max-vw-1440px, $min-padding-section, $max-padding-section); /* This is the same dimension as .podcasts's top and bottom padding */
+
+  margin-left: rem(16px);
+  margin-right: rem(16px);
 }
 
 .section-title {
@@ -33,42 +21,18 @@
   }
 }
 
-.podcast-grid-one {
+/* All of the styles related to the podcast grid */
+.podcast-grid {
   @include fluid-property('gap', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
-  @include fluid-property('margin-bottom', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
-
-  display: grid;
-  grid-template-columns: minmax(auto, rem(192px));
-  grid-template-rows: 1fr;
-
-  @media screen and (min-width: 460px) {
-    grid-template-columns: repeat(2, minmax(auto, rem(192px)));
-  }
-
-  @media screen and (min-width: 600px) {
-    grid-template-columns: repeat(3, minmax(auto, rem(256px)));
-  }
-}
-
-/* All of the relevant styles nested in .podcasts-part-two */
-.podcasts-part-two {
   @include fluid-property('margin-left', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
   @include fluid-property('margin-right', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
 
-  min-height: 100vh;
-  margin-bottom: rem(72px);
-}
-
-.podcast-grid-two {
-  @include fluid-property('gap', $min-vw-320px, $max-vw-1440px, $min-gap-podcast-grid, $max-gap-podcast-grid);
-
   display: grid;
   grid-template-columns: minmax(auto, rem(192px));
-  grid-template-rows: 1fr 1fr;
+  grid-template-areas: repeat(3, 1fr);
 
   @media screen and (min-width: 460px) {
     grid-template-columns: repeat(2, minmax(auto, rem(192px)));
-    grid-template-rows: 1fr 1fr;
   }
 
   @media screen and (min-width: 600px) {
@@ -92,7 +56,7 @@
   }
 }
 
-/* All of the related to the podcast overlays */
+/* All of the styles related to the podcast overlays */
 .podcast-overlay {
   display: flex;
   flex-direction: column;

--- a/src/sass/pages/_contact-html.scss
+++ b/src/sass/pages/_contact-html.scss
@@ -1,6 +1,6 @@
 .page-header-container {
   margin-top: rem(60px);
-  margin-bottom: rem(70px);
+  margin-bottom: rem(72px);
 }
 
 .page-title {


### PR DESCRIPTION
The previous grid layout used two grids to display the podcast images.
This looked good at 1440 x 800, but not on an iPad Pro, or on screens
that are longer than they are wide. Switched to one grid, and gave each
section the same top and bottom padding.